### PR TITLE
Notes about node key not using seed.

### DIFF
--- a/pages/mainnet/validator-setup/keys.mdx
+++ b/pages/mainnet/validator-setup/keys.mdx
@@ -87,7 +87,10 @@ drwxr-xr-x 5 root root 4096 Nov 14 13:38 ..
 
 ## Recovering Your Keys
 
-In case you lose access to your node, you can recover the private keys using the seed phrase. Using the example phrase generated above:
+In case you lose access to your keys, you can recover the private keys using the seed phrase. Using the example phrase generated above:
+<Callout type="info">
+Please note that the `Node Key` cannot be recovered, a new one will be generated. This will result in a new peer id for your node.
+</Callout>
 
 ```bash copy
 chainflip-cli generate-keys \
@@ -95,7 +98,8 @@ chainflip-cli generate-keys \
     --seed-phrase 'spy peanut bless renew berghain gossip exhibit access claim metal flip sample'
 ```
 
-The output should be the same as above, and the keys should be written to the provided path, as above.
+The output should be the same as above (except the `Node Key`), and the keys should be written to the provided path, as above.
+
 
 ## Cleaning Up After Yourself
 

--- a/pages/testnet/maintenance/migrating-to-a-different-server.mdx
+++ b/pages/testnet/maintenance/migrating-to-a-different-server.mdx
@@ -53,13 +53,17 @@ sudo mkdir /etc/chainflip/keys
 
 ### Recovering Your Keys
 
-`THE_OLD_PHARSE` \<< change to your old pharse you have backuped.
+`THE_OLD_PHRASE` \<< change to your old phrase you have backed up.
 
 ```bash copy
 chainflip-cli generate-keys \
     --path /etc/chainflip/keys \
-    --seed-phrase 'THE_OLD_PHARSE'
+    --seed-phrase 'THE_OLD_PHRASE'
 ```
+
+<Callout type="info">
+Please note that the `Node Key` cannot be recovered, a new one will be generated. This will result in a new peer id for your node.
+</Callout>
 
 
 ### Back Them Up & Copy Your Validator ID

--- a/pages/testnet/validator-setup/keys.mdx
+++ b/pages/testnet/validator-setup/keys.mdx
@@ -66,7 +66,10 @@ The *private* keys generated above should have been stored at the path provided 
 
 ## Recovering Your Keys
 
-In case you lose access to your keys, you can recover the private keys using the seed phrase. Please note that the `Node Key` cannot be recovered, a new one must be generated. Using the example phrase generated above:
+In case you lose access to your keys, you can recover the private keys using the seed phrase. Using the example phrase generated above:
+<Callout type="info">
+Please note that the `Node Key` cannot be recovered, a new one will be generated. This will result in a new peer id for your node.
+</Callout>
 
 ```bash copy
 chainflip-cli generate-keys \


### PR DESCRIPTION
Had someone on discord ask why his keys are different. We only had a note about the node key no being generated using the seed in the testnet docs, so I updated the note and put it in all 3 places we mention the `generate-keys` cli cmd.