### PR TITLE
fix: Move minimum price description out of table

### DIFF
--- a/pages/swapping/integrations/javascript-sdk/swap-assets/request-deposit-address.mdx
+++ b/pages/swapping/integrations/javascript-sdk/swap-assets/request-deposit-address.mdx
@@ -213,6 +213,12 @@ This allows to protect against price changes between a quote and the execution o
 If the minimum price cannot be met with the available liquidity during the specified number of blocks, deposited assets will
 be refunded to the specified refund address.
 
+A minimum accepted price is specified as the ratio between the human readable destination amount and the human readable source amount
+(eg. `3500` for a swap from ETH to USDC). Prices are checked on the AMM level and do not include deposit or broadcast fees.
+To calculate a `minPrice` based on a [quote](../get-quote.md), the `estimatedPrice` value is multiplied
+with the desired slippage tolerance. For example, `quote.estimatedPrice * 99 / 100` specifies a 1% slippage
+tolerance relative to the quote.
+
 Refunds are subject to a deposit fee and a broadcast fee on the source chain to pay for the transactions sent
 by the Chainflip protocol. If the deposit address has a broker fee, it will be deducted from the refund amount.
 
@@ -230,13 +236,7 @@ by the Chainflip protocol. If the deposit address has a broker fee, it will be d
         <code>minPrice</code><span class="param-required-label">(required)</span>
       </td>
       <td>
-        Minimum accepted price for swaps triggered through the deposit channel. A price is the ratio between
-        the human readable destination amount and the human readable source amount (eg. `3500` for a swap from ETH to USDC).
-        Prices are checked on the AMM level and do not include deposit or broadcast fees.
-
-        To calculate a `minPrice` based on a [quote](../get-quote.md), the `estimatedPrice` value is multiplied
-        with the desired slippage tolerance. For example, `quote.estimatedPrice * 99 / 100` specifies a 1% slippage
-        tolerance relative to the quote.
+        Minimum accepted price for swaps triggered through the deposit channel.
       </td>
       <td><code>string</code></td>
     </tr>


### PR DESCRIPTION
Seems like the tables dont support markdown.

<img width="807" alt="Screenshot 2024-08-19 at 12 15 52" src="https://github.com/user-attachments/assets/32c4c896-ef69-4595-a7de-4ca35299628a">
