### PR TITLE
feat: updates around broker fees for 1.6

### DIFF
--- a/pages/concepts/swaps-amm/deposit-channels-and-brokers.mdx
+++ b/pages/concepts/swaps-amm/deposit-channels-and-brokers.mdx
@@ -53,7 +53,8 @@ This places the burden of spam prevention on the Broker. If their endpoint is ab
 
 This design then raises the question: why would anyone run a Broker if they have to pay for third parties to use it, especially when those third parties may be malicious?
 
-The answer lies in Broker Fees. Broker operators can choose to charge a fee for the use of their endpoint, and can be set at any value from 0 basis point to 1000 basis points. When set to more than zero, the network will charge an additional fee which is deducted from the deposit amount, in the deposit asset. **This fee is taken immediately after the deposit is witnessed and credited to the broker's account**.
+The answer lies in Broker Fees. Broker operators can choose to charge a fee for the use of their endpoint, and can be set at any value from 0 basis point to 1000 basis points.
+When set to more than zero, the network will charge an additional fee which, like the [network fee](../token-economics/incentive-design-emission-and-burning#the-network-fee), is deducted from the USDC amount of every successful swap and credited to the broker's account.
 
 This way, anyone wishing to integrate Chainflip into their wallet, web interface, or other Web3 products can benefit from getting their users trading on the protocol. The better the balance Broker operators can strike between attracting users and managing Deposit Channel Request transaction fees, the more profits they can expect to make.
 

--- a/pages/swapping/integrations/running-a-broker/affiliate-brokers.mdx
+++ b/pages/swapping/integrations/running-a-broker/affiliate-brokers.mdx
@@ -10,18 +10,19 @@ import { Callout } from "@/components";
 
 # Affiliate Brokers
 
-Affiliate Brokers are regular Chainflip accounts with the *Broker* role, without having set up a Chainflip node and Broker API bundles, and benefiting from the operation of regular Brokers. 
+Affiliate Brokers are regular Chainflip accounts with the *Broker* role, without having set up a Chainflip node and Broker API bundles, and benefiting from the operation of regular Brokers.
 
-These type of Brokers don't create deposit channels themselves, however, they still collect fees as "affiliates". 
+These type of Brokers don't create deposit channels themselves, however, they still collect fees as "affiliates".
 
 This feature allows "affiliates" to request Swap Deposit Channels through a Broker API providers, in exchange for a share of commission.
 
 
-## How it works 
+## How it works
 
 When a Broker, running the Broker API bundle, opens a Swap Deposit Channel, they can optionally specify a list of up to five (5) additional *Affiliate Brokers*, in addition to their own commission.
 
-This commission can be set at the time of deposit channel creation, which provides additional flexibility. Each affiliate receives their share out of all deposits made (and confirmed) while the deposit channel is open.
+This commission can be set at the time of deposit channel creation, which provides additional flexibility.
+Each affiliate receives their share out of all successful swaps coming through the deposit channel while it is open.
 
 
 <Callout type="warning">
@@ -36,9 +37,9 @@ See the [API documentation](broker-api#broker_request_swap_deposit_address) to l
 <img src="/swapping/affiliate_brokers.png" alt="Affiliate Brokers example" />
 <br />
 
-In the first example, Broker #1 and Broker #2 are two different Chainflip accounts with the Broker role, separately running the Broker API bundle, and opening Swap Deposit Channels on behalf of users, collecting 100bps in fees for each deposit made.
+In the first example, Broker #1 and Broker #2 are two different Chainflip accounts with the Broker role, separately running the Broker API bundle, and opening Swap Deposit Channels on behalf of users, collecting 100bps in fees on every successful swap.
 
-With Affiliate Brokers, Broker #1 is now able to run the Broker API and open Swap Deposit Channels with Broker #2 as the beneficiary, each collecting 50bps in fees for each deposit made.
+With Affiliate Brokers, Broker #1 is now able to run the Broker API and open Swap Deposit Channels with Broker #2 as the beneficiary, each collecting 50bps in fees on every successful swap.
 
 Brokers are able to set different affiliates and commission splits on a per channel basis.
 

--- a/pages/swapping/integrations/running-a-broker/broker-api.mdx
+++ b/pages/swapping/integrations/running-a-broker/broker-api.mdx
@@ -91,7 +91,7 @@ OPTIONS:
         --state_chain.ws_endpoint <WS_ENDPOINT>
             The state chain node's rpc endpoint. [default: ws://localhost:9944]
 
-    -v, --version 
+    -v, --version
             Print the version of the API
 ```
 
@@ -108,11 +108,12 @@ Parameters:
 - `boost_fee`: (Optional) Maximum accepted boost fee in basis points (100th of a percent).
 - `affiliate_fees`: (Optional) Array of affiliate brokers (up to 5).
 - `refund_parameters`: (Optional) [Minimum accepted price](../../swapping-basics.mdx) for swaps through the channel as JSON object: `{"retry_duration": <number>, "refund_address": <address>, "min_price": <price>}`. Where `retry_duration` is a number of blocks, `refund_address` is an [address](#addresses), and `min_price` is a [price](#price).
+- `dca_parameters`: (Optional) DCA parameters for swaps through the channel as JSON object: `{"number_of_chunks": <number>, "chunk_interval": <number>}`. Where `number_of_chunks` is the number of "sub-swaps" to perform, and `chunk_interval` is the delay between them in number of blocks.
 
-Where every affiliate broker is defined as follow: 
-```json copy 
+Where every affiliate broker is defined as follow:
+```json copy
 {
-	account: AccountId, 
+	account: AccountId,
 	bps: BasisPoints,
 }
 ```

--- a/pages/swapping/swapping-basics.mdx
+++ b/pages/swapping/swapping-basics.mdx
@@ -61,7 +61,7 @@ If a swap is triggered through a deposit channel with a minimum accepted price, 
 If this is not possible within the specified retry duration, the deposited assets will be refunded to the specified refund address on the source chain.
 
 Minimum accepted prices are enforced on the AMM level and do not take deposit fees and broadcast fees into account.
-If a deposit is refunded, the Chainflip protocol deducts a deposit fee and a broadcast fee from the refund amount to pay for the transactions sent by the protocol. If the deposit address has a broker fee, it will be deducted from the refund amount.
+If a deposit is refunded, the Chainflip protocol deducts a deposit fee and a broadcast fee from the refund amount to pay for the transactions sent by the protocol.
 
 ## USDC as an intermediate asset
 


### PR DESCRIPTION
- Updated every meniton of broker fee being charged on deposit to being charged on successful swap and in USDC
- Removed statement saying the broker fee is deducted from the refund amount
- Also added `dca_parameters` to `broker_request_swap_deposit_address`; I wasn't sure whether to create a new section about DCA or whether someone from the product wanted to do this (I'm not even sure if we even going to call it DCA externally?). I think it is still valuable to add the parameter already since to most integrations it will be mostly self-explanatory.