### PR TITLE
chore: update default config options for rpc nodes

### DIFF
--- a/pages/validators/misc/running-an-rpc-node.mdx
+++ b/pages/validators/misc/running-an-rpc-node.mdx
@@ -119,6 +119,7 @@ Our pre-configured RPC node is available as a debian package in our `apt` reposi
     --rpc-cors=all \
     --rpc-methods=unsafe \
     --unsafe-rpc-external \
+    --max-runtime-instances=32 \
     --sync=warp
 ```
 
@@ -150,6 +151,7 @@ ExecStart=/usr/bin/chainflip-node \
             --rpc-methods=unsafe \
             --unsafe-rpc-external \
             --sync=warp \
+            --max-runtime-instances=32 \
             --prometheus-external
 ```
 


### PR DESCRIPTION
Updated in: 
https://github.com/chainflip-io/chainflip-mainnet-apis/commit/cf2ec26939a5a2444e6ffe85bf4674312be5b1b3
and 
https://github.com/chainflip-io/chainflip-backend/pull/5208 (will only be available by default in 1.7+)