### PR TITLE
Update --help text for broker and lp api.

### DIFF
--- a/pages/lp/integrations/lp-api.mdx
+++ b/pages/lp/integrations/lp-api.mdx
@@ -35,10 +35,10 @@ OPTIONS:
             Print help information
 
         --health_check.hostname <HEALTH_CHECK_HOSTNAME>
-            Hostname for this server's healthcheck. Requires HEALTH_CHECK_PORT to be given as well.
+            Hostname for this server's healthcheck. Requires the <HEALTH_CHECK_PORT> parameter to be given as well.
 
         --health_check.port <HEALTH_CHECK_PORT>
-            Port for this server's healthcheck. Requires HEALTH_CHECK_HOSTNAME to be given as well.
+            Port for this server's healthcheck. Requires the <HEALTH_CHECK_HOSTNAME> parameter to be given as well.
 
         --port <PORT>
             The port number on which the LP server will listen for connections. Use 0 to assign a

--- a/pages/lp/integrations/lp-api.mdx
+++ b/pages/lp/integrations/lp-api.mdx
@@ -35,10 +35,10 @@ OPTIONS:
             Print help information
 
         --health_check.hostname <HEALTH_CHECK_HOSTNAME>
-            Hostname for this server's healthcheck. Requires HEALTH_CHECK_PORT to be set as well.
+            Hostname for this server's healthcheck. Requires HEALTH_CHECK_PORT to be given as well.
 
         --health_check.port <HEALTH_CHECK_PORT>
-            Port for this server's healthcheck. Requires HEALTH_CHECK_HOSTNAME to be set as well.
+            Port for this server's healthcheck. Requires HEALTH_CHECK_HOSTNAME to be given as well.
 
         --port <PORT>
             The port number on which the LP server will listen for connections. Use 0 to assign a

--- a/pages/lp/integrations/lp-api.mdx
+++ b/pages/lp/integrations/lp-api.mdx
@@ -35,18 +35,20 @@ OPTIONS:
             Print help information
 
         --health_check.hostname <HEALTH_CHECK_HOSTNAME>
-            Hostname for this server's healthcheck. Requires the <HEALTH_CHECK_PORT> parameter to be given as well.
+            Hostname for this server's healthcheck. Requires the <HEALTH_CHECK_PORT> parameter to be
+            given as well.
 
         --health_check.port <HEALTH_CHECK_PORT>
-            Port for this server's healthcheck. Requires the <HEALTH_CHECK_HOSTNAME> parameter to be given as well.
+            Port for this server's healthcheck. Requires the <HEALTH_CHECK_HOSTNAME> parameter to be
+            given as well.
 
         --port <PORT>
             The port number on which the LP server will listen for connections. Use 0 to assign a
             random port. [default: 80]
 
         --state_chain.signing_key_file <SIGNING_KEY_FILE>
-            A path to a file that contains the LP's secret key for signing extrinsics. [default:
-            /etc/chainflip/keys/signing_key_file]
+            A path to a file that contains the LP's secret key for signing extrinsics.
+            [default: /etc/chainflip/keys/signing_key_file]
 
         --state_chain.ws_endpoint <WS_ENDPOINT>
             The state chain node's RPC endpoint. [default: ws://localhost:9944]

--- a/pages/lp/integrations/lp-api.mdx
+++ b/pages/lp/integrations/lp-api.mdx
@@ -19,7 +19,7 @@ The LP API bundle exposes a JSON API that allows liquidity providers to easily i
 - The `state_chain.ws_endpoint` should point at a **synced Chainflip State Chain RPC node**. The default is `ws://localhost:9944` — assuming it is run locally.
 - The `state_chain.signing_key_file` should be the **LP's private key** for their on-chain account. The account should be [funded](/mainnet/validator-setup/funding-and-bidding#adding-funds-to-your-validator-node). The account type should be set to LP. The default is `/etc/chainflip/keys/signing_key_file`.
 - The `port` is the port on which the LP will listen for connections. Use `0` to assign a random port. The default is `80`.
-- The `health_check.hostname` and `health_check.port` describe the hostname and port where the LP will listen for health check requests. Both arguments have to be specified. If none are, health check functionality is not provided.
+- The `health_check.hostname` and `health_check.port` describe the hostname and port where the LP will listen for health check requests. Both arguments have to be specified for the health check server to start. This functionality is going to be available from version 1.7+.
 
 ```bash copy
 ./chainflip-lp-api --help

--- a/pages/lp/integrations/lp-api.mdx
+++ b/pages/lp/integrations/lp-api.mdx
@@ -16,7 +16,10 @@ The LP API bundle exposes a JSON API that allows liquidity providers to easily i
 
 ## Command line arguments
 
-The `ws_endpoint` should point at a synced RPC node, the `signing_key_file` should be the **private key** for their on-chain account, and that account should already be [funded](../../../perseverance/funding/funding-and-bidding).
+- The `state_chain.ws_endpoint` should point at a **synced Chainflip State Chain RPC node**. The default is `ws://localhost:9944` — assuming it is run locally.
+- The `state_chain.signing_key_file` should be the **LP's private key** for their on-chain account. The account should be [funded](/mainnet/validator-setup/funding-and-bidding#adding-funds-to-your-validator-node). The account type should be set to LP. The default is `/etc/chainflip/keys/signing_key_file`.
+- The `port` is the port on which the LP will listen for connections. Use `0` to assign a random port. The default is `80`.
+- The `health_check.hostname` and `health_check.port` describe the hostname and port where the LP will listen for health check requests. Both arguments have to be specified. If none are, health check functionality is not provided.
 
 ```bash copy
 ./chainflip-lp-api --help
@@ -31,19 +34,27 @@ OPTIONS:
     -h, --help
             Print help information
 
+        --health_check.hostname <health_check.hostname>
+            Hostname for this LP server's healthcheck. Requires --health_check.port to be present as
+            well.
+
+        --health_check.port <health_check.port>
+            Port for this LP server's healthcheck. Requires --health_check.hostname to be present as
+            well.
+
         --port <PORT>
             The port number on which the LP server will listen for connections. Use 0 to assign a
             random port. [default: 80]
 
         --state_chain.signing_key_file <SIGNING_KEY_FILE>
-            A path to a file that contains the LPs secret key for signing extrinsics.
-            [default: /etc/chainflip/keys/signing_key_file]
+            A path to a file that contains the LP's secret key for signing extrinsics. [default:
+            /etc/chainflip/keys/signing_key_file]
 
         --state_chain.ws_endpoint <WS_ENDPOINT>
-            The state chain nodes RPC endpoint. [default: ws://localhost:9944]
+            The state chain node's RPC endpoint. [default: ws://localhost:9944]
 
     -v, --version
-            Print the version of the API
+            Print version information
 ```
 
 ## RPC Parameters

--- a/pages/lp/integrations/lp-api.mdx
+++ b/pages/lp/integrations/lp-api.mdx
@@ -17,9 +17,9 @@ The LP API bundle exposes a JSON API that allows liquidity providers to easily i
 ## Command line arguments
 
 - The `state_chain.ws_endpoint` should point at a **synced Chainflip State Chain RPC node**. The default is `ws://localhost:9944` — assuming it is run locally.
-- The `state_chain.signing_key_file` should be the **LP's private key** for their on-chain account. The account should be [funded](/mainnet/validator-setup/funding-and-bidding#adding-funds-to-your-validator-node). The account type should be set to LP. The default is `/etc/chainflip/keys/signing_key_file`.
-- The `port` is the port on which the LP will listen for connections. Use `0` to assign a random port. The default is `80`.
-- New functionality available from version 1.7+: The `health_check.hostname` and `health_check.port` describe the hostname and port where the LP will listen for health check requests. Both arguments have to be specified for the health check server to start.
+- The `state_chain.signing_key_file` should be a path to a file containing the hex-encoded **private key** for the on-chain LP account. The default file path is `/etc/chainflip/keys/signing_key_file`. The account should be [funded](/mainnet/validator-setup/funding-and-bidding#adding-funds-to-your-validator-node) and the account role should be set to LP. 
+- The `port` is the port on which the LP API will listen for connections. Use `0` to assign a random port. The default is `80`.
+- New functionality available from version 1.7+: The `health_check.hostname` and `health_check.port` describe the hostname and port where the LP API will listen for health check requests. Both arguments have to be specified for the health check server to start.
 
 ```bash copy
 ./chainflip-lp-api --help

--- a/pages/lp/integrations/lp-api.mdx
+++ b/pages/lp/integrations/lp-api.mdx
@@ -34,13 +34,11 @@ OPTIONS:
     -h, --help
             Print help information
 
-        --health_check.hostname <health_check.hostname>
-            Hostname for this LP server's healthcheck. Requires --health_check.port to be present as
-            well.
+        --health_check.hostname <HEALTH_CHECK_HOSTNAME>
+            Hostname for this server's healthcheck. Requires HEALTH_CHECK_PORT to be set as well.
 
-        --health_check.port <health_check.port>
-            Port for this LP server's healthcheck. Requires --health_check.hostname to be present as
-            well.
+        --health_check.port <HEALTH_CHECK_PORT>
+            Port for this server's healthcheck. Requires HEALTH_CHECK_HOSTNAME to be set as well.
 
         --port <PORT>
             The port number on which the LP server will listen for connections. Use 0 to assign a

--- a/pages/lp/integrations/lp-api.mdx
+++ b/pages/lp/integrations/lp-api.mdx
@@ -19,7 +19,7 @@ The LP API bundle exposes a JSON API that allows liquidity providers to easily i
 - The `state_chain.ws_endpoint` should point at a **synced Chainflip State Chain RPC node**. The default is `ws://localhost:9944` — assuming it is run locally.
 - The `state_chain.signing_key_file` should be the **LP's private key** for their on-chain account. The account should be [funded](/mainnet/validator-setup/funding-and-bidding#adding-funds-to-your-validator-node). The account type should be set to LP. The default is `/etc/chainflip/keys/signing_key_file`.
 - The `port` is the port on which the LP will listen for connections. Use `0` to assign a random port. The default is `80`.
-- The `health_check.hostname` and `health_check.port` describe the hostname and port where the LP will listen for health check requests. Both arguments have to be specified for the health check server to start. This functionality is going to be available from version 1.7+.
+- New functionality available from version 1.7+: The `health_check.hostname` and `health_check.port` describe the hostname and port where the LP will listen for health check requests. Both arguments have to be specified for the health check server to start.
 
 ```bash copy
 ./chainflip-lp-api --help

--- a/pages/swapping/integrations/running-a-broker/broker-api.mdx
+++ b/pages/swapping/integrations/running-a-broker/broker-api.mdx
@@ -82,10 +82,10 @@ OPTIONS:
             Print help information
 
         --health_check.hostname <HEALTH_CHECK_HOSTNAME>
-            Hostname for this server's healthcheck. Requires HEALTH_CHECK_PORT to be set as well.
+            Hostname for this server's healthcheck. Requires HEALTH_CHECK_PORT to be given as well.
 
         --health_check.port <HEALTH_CHECK_PORT>
-            Port for this server's healthcheck. Requires HEALTH_CHECK_HOSTNAME to be set as well.
+            Port for this server's healthcheck. Requires HEALTH_CHECK_HOSTNAME to be given as well.
 
         --max_connections <MAX_CONNECTIONS>
             The maximum number of concurrent websocket connections to accept. [default: 100]

--- a/pages/swapping/integrations/running-a-broker/broker-api.mdx
+++ b/pages/swapping/integrations/running-a-broker/broker-api.mdx
@@ -82,10 +82,10 @@ OPTIONS:
             Print help information
 
         --health_check.hostname <HEALTH_CHECK_HOSTNAME>
-            Hostname for this server's healthcheck. Requires HEALTH_CHECK_PORT to be given as well.
+            Hostname for this server's healthcheck. Requires the <HEALTH_CHECK_PORT> parameter to be given as well.
 
         --health_check.port <HEALTH_CHECK_PORT>
-            Port for this server's healthcheck. Requires HEALTH_CHECK_HOSTNAME to be given as well.
+            Port for this server's healthcheck. Requires the <HEALTH_CHECK_HOSTNAME> parameter to be given as well.
 
         --max_connections <MAX_CONNECTIONS>
             The maximum number of concurrent websocket connections to accept. [default: 100]

--- a/pages/swapping/integrations/running-a-broker/broker-api.mdx
+++ b/pages/swapping/integrations/running-a-broker/broker-api.mdx
@@ -81,13 +81,11 @@ OPTIONS:
     -h, --help
             Print help information
 
-        --health_check.hostname <health_check.hostname>
-            Hostname for this LP server's healthcheck. Requires --health_check.port to be present as
-            well.
+        --health_check.hostname <HEALTH_CHECK_HOSTNAME>
+            Hostname for this server's healthcheck. Requires HEALTH_CHECK_PORT to be set as well.
 
-        --health_check.port <health_check.port>
-            Port for this LP server's healthcheck. Requires --health_check.hostname to be present as
-            well.
+        --health_check.port <HEALTH_CHECK_PORT>
+            Port for this server's healthcheck. Requires HEALTH_CHECK_HOSTNAME to be set as well.
 
         --max_connections <MAX_CONNECTIONS>
             The maximum number of concurrent websocket connections to accept. [default: 100]

--- a/pages/swapping/integrations/running-a-broker/broker-api.mdx
+++ b/pages/swapping/integrations/running-a-broker/broker-api.mdx
@@ -66,7 +66,7 @@ After being funded, before you can fully interact with the Broker API, your acco
 - The `state_chain.ws_endpoint` should point at a **synced Chainflip State Chain RPC node**. The default is `ws://localhost:9944` — assuming it is run locally.
 - The `state_chain.signing_key_file` should be the **Broker's private key** for their on-chain account. The account should be [funded](/mainnet/validator-setup/funding-and-bidding#adding-funds-to-your-validator-node). The account type should be set to Broker. The default is `/etc/chainflip/keys/signing_key_file`.
 - The `port` is the port on which the Broker will listen for connections. Use `0` to assign a random port. The default is `80`.
-- The `health_check.hostname` and `health_check.port` describe the hostname and port where the Broker will listen for health check requests. Both arguments have to be specified for the health check server to start. This functionality is going to be available from version 1.7+.
+- New functionality available from version 1.7+: The `health_check.hostname` and `health_check.port` describe the hostname and port where the Broker will listen for health check requests. Both arguments have to be specified for the health check server to start.
 
 ```bash copy
 chainflip-broker-api --help

--- a/pages/swapping/integrations/running-a-broker/broker-api.mdx
+++ b/pages/swapping/integrations/running-a-broker/broker-api.mdx
@@ -82,10 +82,12 @@ OPTIONS:
             Print help information
 
         --health_check.hostname <HEALTH_CHECK_HOSTNAME>
-            Hostname for this server's healthcheck. Requires the <HEALTH_CHECK_PORT> parameter to be given as well.
+            Hostname for this server's healthcheck. Requires the <HEALTH_CHECK_PORT> parameter to be
+            given as well.
 
         --health_check.port <HEALTH_CHECK_PORT>
-            Port for this server's healthcheck. Requires the <HEALTH_CHECK_HOSTNAME> parameter to be given as well.
+            Port for this server's healthcheck. Requires the <HEALTH_CHECK_HOSTNAME> parameter to be
+            given as well.
 
         --max_connections <MAX_CONNECTIONS>
             The maximum number of concurrent websocket connections to accept. [default: 100]
@@ -95,8 +97,8 @@ OPTIONS:
             random port. [default: 80]
 
         --state_chain.signing_key_file <SIGNING_KEY_FILE>
-            A path to a file that contains the broker's secret key for signing extrinsics. [default:
-            /etc/chainflip/keys/signing_key_file]
+            A path to a file that contains the broker's secret key for signing extrinsics.
+            [default: /etc/chainflip/keys/signing_key_file]
 
         --state_chain.ws_endpoint <WS_ENDPOINT>
             The state chain node's RPC endpoint. [default: ws://localhost:9944]

--- a/pages/swapping/integrations/running-a-broker/broker-api.mdx
+++ b/pages/swapping/integrations/running-a-broker/broker-api.mdx
@@ -66,6 +66,7 @@ After being funded, before you can fully interact with the Broker API, your acco
 - The `state_chain.ws_endpoint` should point at a **synced Chainflip State Chain RPC node**. The default is `ws://localhost:9944` — assuming it is run locally.
 - The `state_chain.signing_key_file` should be the **Broker's private key** for their on-chain account. The account should be [funded](/mainnet/validator-setup/funding-and-bidding#adding-funds-to-your-validator-node). The account type should be set to Broker. The default is `/etc/chainflip/keys/signing_key_file`.
 - The `port` is the port on which the Broker will listen for connections. Use `0` to assign a random port. The default is `80`.
+- The `health_check.hostname` and `health_check.port` describe the hostname and port where the Broker will listen for health check requests. Both arguments have to be specified. If none are, health check functionality is not provided.
 
 ```bash copy
 chainflip-broker-api --help
@@ -80,19 +81,30 @@ OPTIONS:
     -h, --help
             Print help information
 
+        --health_check.hostname <health_check.hostname>
+            Hostname for this LP server's healthcheck. Requires --health_check.port to be present as
+            well.
+
+        --health_check.port <health_check.port>
+            Port for this LP server's healthcheck. Requires --health_check.hostname to be present as
+            well.
+
+        --max_connections <MAX_CONNECTIONS>
+            The maximum number of concurrent websocket connections to accept. [default: 100]
+
         --port <PORT>
             The port number on which the broker will listen for connections. Use 0 to assign a
             random port. [default: 80]
 
         --state_chain.signing_key_file <SIGNING_KEY_FILE>
-            A path to a file that contains the broker's secret key for signing extrinsics.
-            [default: /etc/chainflip/keys/signing_key_file]
+            A path to a file that contains the broker's secret key for signing extrinsics. [default:
+            /etc/chainflip/keys/signing_key_file]
 
         --state_chain.ws_endpoint <WS_ENDPOINT>
-            The state chain node's rpc endpoint. [default: ws://localhost:9944]
+            The state chain node's RPC endpoint. [default: ws://localhost:9944]
 
     -v, --version
-            Print the version of the API
+            Print version information
 ```
 
 ## 3. Using the Broker: RPC Methods

--- a/pages/swapping/integrations/running-a-broker/broker-api.mdx
+++ b/pages/swapping/integrations/running-a-broker/broker-api.mdx
@@ -64,9 +64,9 @@ After being funded, before you can fully interact with the Broker API, your acco
 ### Command line arguments and defaults
 
 - The `state_chain.ws_endpoint` should point at a **synced Chainflip State Chain RPC node**. The default is `ws://localhost:9944` — assuming it is run locally.
-- The `state_chain.signing_key_file` should be the **Broker's private key** for their on-chain account. The account should be [funded](/mainnet/validator-setup/funding-and-bidding#adding-funds-to-your-validator-node). The account type should be set to Broker. The default is `/etc/chainflip/keys/signing_key_file`.
-- The `port` is the port on which the Broker will listen for connections. Use `0` to assign a random port. The default is `80`.
-- New functionality available from version 1.7+: The `health_check.hostname` and `health_check.port` describe the hostname and port where the Broker will listen for health check requests. Both arguments have to be specified for the health check server to start.
+- The `state_chain.signing_key_file` should be a path to a file containing the hex-encoded **private key** for the on-chain Broker account. The default file path is `/etc/chainflip/keys/signing_key_file`. The account should be [funded](/mainnet/validator-setup/funding-and-bidding#adding-funds-to-your-validator-node) and the account role should be set to Broker.
+- The `port` is the port on which the Broker API will listen for connections. Use `0` to assign a random port. The default is `80`.
+- New functionality available from version 1.7+: The `health_check.hostname` and `health_check.port` describe the hostname and port where the Broker API will listen for health check requests. Both arguments have to be specified for the health check server to start.
 
 ```bash copy
 chainflip-broker-api --help

--- a/pages/swapping/integrations/running-a-broker/broker-api.mdx
+++ b/pages/swapping/integrations/running-a-broker/broker-api.mdx
@@ -66,7 +66,7 @@ After being funded, before you can fully interact with the Broker API, your acco
 - The `state_chain.ws_endpoint` should point at a **synced Chainflip State Chain RPC node**. The default is `ws://localhost:9944` — assuming it is run locally.
 - The `state_chain.signing_key_file` should be the **Broker's private key** for their on-chain account. The account should be [funded](/mainnet/validator-setup/funding-and-bidding#adding-funds-to-your-validator-node). The account type should be set to Broker. The default is `/etc/chainflip/keys/signing_key_file`.
 - The `port` is the port on which the Broker will listen for connections. Use `0` to assign a random port. The default is `80`.
-- The `health_check.hostname` and `health_check.port` describe the hostname and port where the Broker will listen for health check requests. Both arguments have to be specified. If none are, health check functionality is not provided.
+- The `health_check.hostname` and `health_check.port` describe the hostname and port where the Broker will listen for health check requests. Both arguments have to be specified for the health check server to start. This functionality is going to be available from version 1.7+.
 
 ```bash copy
 chainflip-broker-api --help


### PR DESCRIPTION
Since a `health_check` CLI arg is being added to both the LP and Broker apis in https://github.com/chainflip-io/chainflip-backend/pull/5282, this accompanying PR updates the `--help` text description in the documentation.

I also reformatted the description above the help text for the LP to be in line with how the Broker is described. It seems to have been somewhat out of date.