### PR TITLE
typo: remove random word

### DIFF
--- a/pages/swapping/integrations/advanced/vault-swaps.mdx
+++ b/pages/swapping/integrations/advanced/vault-swaps.mdx
@@ -132,7 +132,6 @@ Invalid parameters may lead to loss of funds. Make sure all parameters are corre
       </td>
       <td>
         Message that is passed to the destination address on the destination. It must be shorter than 10k bytes.
-        chain
       </td>
       <td><code>bytes</code></td>
     </tr>


### PR DESCRIPTION
"chain" is just floating there