### PR TITLE
chore: add clarification evm

### DIFF
--- a/pages/swapping/integrations/advanced/vault-swaps.mdx
+++ b/pages/swapping/integrations/advanced/vault-swaps.mdx
@@ -272,8 +272,7 @@ contract CFReceiver {
 }
 ```
 
-You can find an example of a receiver contract that can be inherited [here](https://github.com/chainflip-io/chainflip-eth-contracts/blob/master/contracts/abstract/CFReceiver.sol).
-
+You can find an example of an implementation of a receiver contract with the mentioned interface [here](https://github.com/chainflip-io/chainflip-eth-contracts/blob/master/contracts/abstract/CFReceiver.sol). The contract also has other logic that is not necesary like the `cfReceivexCall` (currently unsupported) or the logic to update the `cfVault` address.
 
 <Callout type="warning">
 


### PR DESCRIPTION
Clarify that all logic in the CfTester is not needed.