### PR TITLE
Fixed broken URLs for `request-deposit-address`

### DIFF
--- a/pages/swapping/integrations/javascript-sdk/swap-assets/execute-swap.mdx
+++ b/pages/swapping/integrations/javascript-sdk/swap-assets/execute-swap.mdx
@@ -10,7 +10,7 @@ import { Callout } from "@/components";
 
 # Execute Swap
 
-Alternatively, calling the `swap()` function in the Chainflip Vault contracts allows to initiate a swap immediately. The swap is then triggered without the need of a [Deposit Channel](request-deposit-address.md) and therefore, no [Broker](../../running-a-broker/introduction) is necessary.
+Alternatively, calling the `swap()` function in the Chainflip Vault contracts allows to initiate a swap immediately. The swap is then triggered without the need of a [Deposit Channel](request-deposit-address/v2.md) and therefore, no [Broker](../../running-a-broker/introduction) is necessary.
 
 Using smart contract calls is **faster than requesting a deposit address** but also more expensive (more gas involved on approving token and amount allowance).
 

--- a/pages/swapping/integrations/javascript-sdk/swap-assets/introduction.mdx
+++ b/pages/swapping/integrations/javascript-sdk/swap-assets/introduction.mdx
@@ -16,7 +16,7 @@ Chainflip swaps are **fire-and-forget**, meaning once the deposit is made, the u
 
 There are two main ways to initiate a swap:
 
-1. **Creating a deposit channel** via a Broker in order to get a deposit address. See [Request Deposit Address](request-deposit-address.md).
+1. **Creating a deposit channel** via a Broker in order to get a deposit address. See [Request Deposit Address](request-deposit-address/v2.md).
 2. **Calling the Vault smart contracts directly**, via the `swap()` or `call()` functions — for EVM-only chains. See [Execute Swap](execute-swap.md).
 
 <Callout type="info">


### PR DESCRIPTION
Fixed broken URLs for `request-deposit-address` to `request-deposit-address/v2` in `swap-assets/introduction` & `swap-assets/execute-swap`.