### PR TITLE
default the arbitrum key to be the ethereum key

### DIFF
--- a/pages/validators/mainnet/validator-setup/engine-settings.mdx
+++ b/pages/validators/mainnet/validator-setup/engine-settings.mdx
@@ -82,9 +82,8 @@ http_endpoint = "my_local_btc_node:8332"
 
 [arb]
 # Arbitrum private key file path. This file should contain a hex-encoded private key.
-# Note: You could use the same private key file as Ethereum if you want to use the same key for both chains.
-# This is up to you.
-private_key_file = "/etc/chainflip/keys/arbitrum_key_file"
+# Note: Here we use the same private key file as Ethereum. You can use a different key if you want.
+private_key_file = "/etc/chainflip/keys/ethereum_key_file"
 
 [arb.rpc]
 ws_endpoint = "ws://my_local_arbitrum_node:8548"

--- a/pages/validators/testnet/validator-setup/engine-settings.mdx
+++ b/pages/validators/testnet/validator-setup/engine-settings.mdx
@@ -93,9 +93,8 @@ http_endpoint = "https://testnet.rpc.btc.chainflip.io"
 
 [arb]
 # Arbitrum private key file path. This file should contain a hex-encoded private key.
-# Note: You could use the same private key file as Ethereum if you want to use the same key for both chains.
-# This is up to you.
-private_key_file = "/etc/chainflip/keys/arbitrum_key_file"
+# Note: Here we use the same private key file as Ethereum. You can use a different key if you want.
+private_key_file = "/etc/chainflip/keys/ethereum_key_file"
 
 [arb.rpc]
 ws_endpoint = "ws://my_local_arbitrum_node:8548"


### PR DESCRIPTION
We don't generate a separate arbitrum key when generating keys, so if using the default config and following the steps, it would error because the arbitrum key doesn't exist.

By using the same key for each, it simplifies the validator onboarding, as well as defaulting to the easier key management method, of using 1 key for both chains.