### PR TITLE
fix: vault swap flag param in get quote method[WEB-1794]

### DIFF
--- a/pages/swapping/integrations/javascript-sdk/get-quote/v1.mdx
+++ b/pages/swapping/integrations/javascript-sdk/get-quote/v1.mdx
@@ -93,6 +93,11 @@ The `quoteRequest` object describes the swap for which a quote is returned.
           <td>Array of objects describing the affiliate brokers that charge a commission</td>
           <td><code>Array</code></td>
       </tr>
+      <tr>
+          <td><code>isVaultSwap</code><span class="param-optional-label">(optional)</span></td>
+          <td>A flag indicating whether it is a vault swap. Vault swaps are exempt from ingress fees, so the returned value will be zero</td>
+          <td><code>boolean</code></td>
+      </tr>
    </tbody>
 </table>
 }

--- a/pages/swapping/integrations/javascript-sdk/get-quote/v2.mdx
+++ b/pages/swapping/integrations/javascript-sdk/get-quote/v2.mdx
@@ -97,6 +97,11 @@ The `quoteRequest` object describes the swap for which a quote is returned.
           <td>Array of objects describing the affiliate brokers that charge a commission</td>
           <td><code>Array</code></td>
       </tr>
+      <tr>
+          <td><code>isVaultSwap</code><span class="param-optional-label">(optional)</span></td>
+          <td>A flag indicating whether it is a vault swap. Vault swaps are exempt from ingress fees, so the ingress fee will be zero</td>
+          <td><code>boolean</code></td>
+      </tr>
    </tbody>
 </table>
 }

--- a/pages/swapping/integrations/javascript-sdk/get-quote/v2.mdx
+++ b/pages/swapping/integrations/javascript-sdk/get-quote/v2.mdx
@@ -99,7 +99,7 @@ The `quoteRequest` object describes the swap for which a quote is returned.
       </tr>
       <tr>
           <td><code>isVaultSwap</code><span class="param-optional-label">(optional)</span></td>
-          <td>A flag indicating whether it is a vault swap. Vault swaps are exempt from ingress fees, so the ingress fee will be zero</td>
+          <td>A flag indicating whether it is a vault swap. Vault swaps are exempt from ingress fees, so the returned value will be zero</td>
           <td><code>boolean</code></td>
       </tr>
    </tbody>


### PR DESCRIPTION
Added `isVaultSwap` param to the `getQuote` and`getQuoteV2()` methods

<img width="676" alt="Screenshot 2025-01-17 at 13 52 45" src="https://github.com/user-attachments/assets/4640689f-8d72-42dc-ae12-731076182044" />

Not sure if need to add this param to the examples, since it's just a boolean flag and quite easy to use 😌