### PR TITLE
fix: typo in ccm

### DIFF
--- a/pages/swapping/integrations/advanced/vault-swaps/vault-swaps.mdx
+++ b/pages/swapping/integrations/advanced/vault-swaps/vault-swaps.mdx
@@ -25,7 +25,7 @@ The major benefit of a Vault Swap is that it can be presented to the end-user fo
 The downsides of Vault Swaps are:
 - A Vault Swap transaction is single-use, whereas deposit channels can be used multiple times once opened.
 - A Vault Swap transaction is more complex than a simple transfer to a deposit channel, making integration more challenging and possibly incurring higher fees for Swappers.
-- Cross-chain-messaging from Bitcoin is not supported for Vault Swaps.
+- Cross-chain messaging from Bitcoin is not supported for Vault Swaps.
 - At the time of writing (`v1.8`), Vault Swaps are not supported on Polkadot.
 
 ## How It Works


### PR DESCRIPTION
no dash between chain-messaging to be consistent with the title of CCM in the sidebar