### PR TITLE
LP-API new `lp_request_liquidity_deposit_address` RPC

### DIFF
--- a/pages/lp/integrations/lp-api.mdx
+++ b/pages/lp/integrations/lp-api.mdx
@@ -351,7 +351,14 @@ Returns: The transaction hash of the extrinsic, otherwise an error.
 
 ### `lp_liquidity_deposit`
 
-Submits an extrinsic that opens a deposit address that you can send assets to. Once any assets you send are detected they will be credited to this account's free balance, and can then be used to create orders. We recommend waiting until the extrinsic is finalized before sending any assets to the deposit address to ensure the assets are correctly credited to your account.
+<Callout type="error">
+This RPC is deprecated as of 1.9. 
+Please use the [`lp_request_liquidity_deposit_address`](#lp_request_liquidity_deposit_address) RPC instead.
+</Callout>
+
+Submits an extrinsic that opens a deposit address that you can send assets to.
+Once any assets you send are detected they will be credited to this account's free balance, and can then be used to create orders. 
+We recommend waiting until the extrinsic is finalized before sending any assets to the deposit address to ensure the assets are correctly credited to your account.
 
 Parameters:
 - [`asset`](#asset): The asset you wish to deposit.
@@ -369,7 +376,7 @@ curl -H "Content-Type: application/json" -d '{
   "method": "lp_liquidity_deposit",
   "params": {
     "asset":{"chain":"Bitcoin","asset":"BTC"},
-    "boost_fee":"10"
+    "boost_fee": 10
     }
 }' http://localhost:10589
 ```
@@ -380,6 +387,58 @@ curl -H "Content-Type: application/json" -d '{
     "tx_details": {
       "tx_hash": "0x676157322a644e5ba09f3c097d27ec17ec4768a19a2989ff603506bd42fd1fc4",
       "response": "bcrt1pflqt7c2mncux4l4j56xq84qn98agylesjtgusc5fgjqc0ku8mzfs23eqwz"
+    }
+  },
+  "id": 1
+}
+```
+
+### `lp_request_liquidity_deposit_address`
+
+<Callout type="info">
+This RPC is available from version 1.9 onwards.
+</Callout>
+
+Submits an extrinsic that opens a deposit address that you can send assets to.
+Once any assets you send are detected they will be credited to this account's free balance, and can then be used to create orders. 
+We recommend waiting until the extrinsic is finalized before sending any assets to the deposit address to ensure the assets are correctly credited to your account.
+
+Parameters:
+- [`asset`](#asset): The asset you wish to deposit.
+- [`wait_for`](#wait-for) (Optional)
+- [`boost_fee`](#boost-fee) (Optional): The maximum amount you are willing to pay to [boost](/lp/boost/how-boost-works) the deposit, expressed as basis points.
+
+[Response](#wait-for-result):
+- An object containing The encoded deposit [address](#addresses) and the block number of the deposit chain at which the deposit address will expire.
+```json
+{
+  "deposit_address": <String>,
+  "deposit_chain_expiry_block": <number>
+}
+```
+
+#### Example
+```sh
+curl -H "Content-Type: application/json" -d '{
+  "id":1,
+  "jsonrpc":"2.0",
+  "method": "lp_request_liquidity_deposit_address",
+  "params": {
+    "asset":{"chain":"Bitcoin","asset":"BTC"},
+    "boost_fee": 10
+    }
+}' http://localhost:10589
+```
+```json
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "tx_details": {
+      "tx_hash": "0xfa79d112b6fd0885dff76ebd1604b8493a6d0a018729aa1225d8acc0089997ba",
+      "response": {
+        "deposit_address": "bcrt1psd2tdr340jp7dta3jls2w4z8j5e56evxmwdslqa26x0fua5wczuqrnvpp3",
+        "deposit_chain_expiry_block": 2379
+      }
     }
   },
   "id": 1
@@ -440,7 +499,7 @@ curl -H "Content-Type: application/json" -d '{
   "jsonrpc": "2.0",
   "method": "lp_withdraw_asset",
   "params": {
-    "amount": "1000",
+    "amount": 1000000000000000000,
     "asset": "ETH",
     "destination_address": "0xcfE27Ce6D57B81Ea86046aD1789104E5B7F0a2E7"
   }


### PR DESCRIPTION
Documented the new `request_liquidity_deposit_address` RPC and marked the old one as depreciated.

Fixed a few other small mistakes.