### PR TITLE
chore: add sol two step signing versioned tx

### DIFF
--- a/pages/swapping/integrations/advanced/vault-swaps/solana.mdx
+++ b/pages/swapping/integrations/advanced/vault-swaps/solana.mdx
@@ -183,14 +183,11 @@ for (const account of vaultSwapDetails.accounts) {
   });
 }
 
-const transaction = new Transaction();
 const instruction = new TransactionInstruction({
   keys,
   programId: new PublicKey(vaultSwapDetails.program_id),
   data: Buffer.from(vaultSwapDetails.data.slice(2), 'hex'),
 });
-
-transaction.add(instruction);
 ```
 
 ### 3. Sign and Send
@@ -198,6 +195,9 @@ transaction.add(instruction);
 In the simplest case you can sign and send the transaction created previously in a single step:
 
 ```typescript copy
+const transaction = new Transaction();
+transaction.add(instruction);
+
 await sendAndConfirmTransaction(
   connection,
   transaction,
@@ -208,17 +208,46 @@ await sendAndConfirmTransaction(
 #### Two step signing
 
 It might be useful to separately sign with the `newEventAccountKeypair` and the user keypair. For example to craft a transaction that the final user signs in his wallet and broadcasts automatically, we need to provide a partially signed transaction.
-To do that we can use the following code instead of `sendAndConfirmTransaction`:
+
+##### Versioned transaction V0
+
+Using versioned transactions we can rely on the regular `sign` to sign in two steps:
 
 ```typescript copy
-  transaction.recentBlockhash = (await connection.getLatestBlockhash()).blockhash;
-  // First set the feePayer to the user keypair to sign the transaction. Otherwise
-  // by default the first signer will be the feePayer.
-  transaction.feePayer = userKeypair.publicKey;
-  transaction.partialSign(newEventAccountKeypair);
-  transaction.partialSign(userKeypair);
-  await connection.sendRawTransaction(transaction.serialize());
-  await connection.confirmTransaction(txHash);
+const recentBlockhash = (await connection.getLatestBlockhash()).blockhash;
+
+const messageV0 = new TransactionMessage({
+  payerKey: userKeypair.publicKey,
+  recentBlockhash,
+  instructions: [instruction],
+}).compileToV0Message();
+
+const transaction = new VersionedTransaction(messageV0);
+
+// Sign separately
+transaction.sign([newEventAccountKeypair]);
+transaction.sign([userKeypair]);
+
+txHash = await connection.sendRawTransaction(transaction.serialize());
+await connection.confirmTransaction(txHash);
+```
+
+##### Legacy transaction
+
+Using legacy transactions we must use the `partialSign` instead:
+
+```typescript copy
+const transaction = new Transaction();
+transaction.add(instruction);
+
+transaction.recentBlockhash = (await connection.getLatestBlockhash()).blockhash;
+// First set the feePayer to the user keypair to sign the transaction. Otherwise
+// by default the first signer will be the feePayer.
+transaction.feePayer = userKeypair.publicKey;
+transaction.partialSign(newEventAccountKeypair);
+transaction.partialSign(userKeypair);
+await connection.sendRawTransaction(transaction.serialize());
+await connection.confirmTransaction(txHash);
 ```
 
 ## Interface References

--- a/pages/swapping/integrations/javascript-sdk/swap-assets/encode-vault-swap-data.mdx
+++ b/pages/swapping/integrations/javascript-sdk/swap-assets/encode-vault-swap-data.mdx
@@ -418,6 +418,10 @@ const signature = await sendAndConfirmTransaction(
 const status = await swapSDK.getStatusV2({ id: signature });
 ```
 
+<Callout type="info">
+  Solana Vault swaps require two signatures. There are ways to do this that are more friendly to integrators and wallets described in the [Two step signing section](./../../advanced/vault-swaps/solana.mdx#two-step-signing).
+</Callout>
+
 ```typescript copy
 // console output:
 {


### PR DESCRIPTION
Adding information on signing Versioned transactions in the two step signing process.
Legacy transactions require the `partialSign` which is not supported by wallets.
Related to: https://github.com/chainflip-io/chainflip-backend/pull/5832