### PR TITLE
Prevent Indexing of Testnet and Tracked Docs URLs with Canonical Tags

### DIFF
--- a/theme.config.tsx
+++ b/theme.config.tsx
@@ -12,11 +12,11 @@ const logoStyle = {
 
 const config: DocsThemeConfig = {
   head: () => {
-    {
       const { asPath } = useRouter();
       const url = `https://docs.chainflip.io${asPath}`;
       return (
         <>
+          <link rel="canonical" href={url.split('?')[0]} />
           <link rel="icon" href="/chainflip-favicon.ico" sizes="any" />
           <meta property="og:url" content={url} />
           <meta property="og:type" content="website" />


### PR DESCRIPTION
We discovered that search engines were indexing multiple versions of our documentation pages due to appended query parameters (e.g. ?ref=blog.chainflip.io). This resulted in duplicate content issues, which were flagged in tools like Google Search Console and Semrush. These duplicates can dilute SEO performance and confuse crawlers about which version to prioritize.

While the query parameters were originally used for referral tracking (e.g. from blog posts or marketing campaigns), the docs frontend was rendering these pages as indexable variants, with no canonical reference.