### PR TITLE
feat(docs): add noindex and canonical overrides for testnet pages

### DIFF
--- a/theme.config.tsx
+++ b/theme.config.tsx
@@ -12,23 +12,27 @@ const logoStyle = {
 
 const config: DocsThemeConfig = {
   head: () => {
-    {
-      const { asPath } = useRouter();
-      const url = `https://docs.chainflip.io${asPath}`;
-      return (
-        <>
-          <link rel="canonical" href={url.split('?')[0]} />
-          <link rel="icon" href="/chainflip-favicon.ico" sizes="any" />
-          <meta property="og:url" content={url} />
-          <meta property="og:type" content="website" />
-          <meta
-            property="og:image"
-            content="https://docs.chainflip.io/chainfliplogo.png"
-          />
-        </>
-      );
-    }
-  },
+  const { asPath } = useRouter();
+  const isTestnet = asPath.includes("/validators/testnet/");
+  const url = `https://docs.chainflip.io${asPath}`;
+  const canonical = isTestnet
+    ? url.replace("/validators/testnet/", "/validators/mainnet/").split("?")[0]
+    : url.split("?")[0];
+
+  return (
+    <>
+      <link rel="canonical" href={canonical} />
+      <link rel="icon" href="/chainflip-favicon.ico" sizes="any" />
+      <meta property="og:url" content={url} />
+      <meta property="og:type" content="website" />
+      <meta
+        property="og:image"
+        content="https://docs.chainflip.io/chainfliplogo.png"
+      />
+      {isTestnet && <meta name="robots" content="noindex, nofollow" />}
+    </>
+  );
+},
   logo: (
     <div style={logoStyle}>
       <img height="25" width="25" src="/chainfliplogo.png" />


### PR DESCRIPTION
This update improves SEO hygiene across the Chainflip docs by handling duplicate content between mainnet and testnet pages.

- Dynamically inserts a <meta name="robots" content="noindex, nofollow"> tag for all /validators/testnet/* routes
- Overrides canonical URL on testnet pages to point to the equivalent /validators/mainnet/* path
- Ensures testnet docs remain accessible but are excluded from search engine indexing
- Helps resolve duplicate title and URL issues flagged in SEO

This change affects the head() function in theme.config.tsx and applies automatically across all routes.